### PR TITLE
[CRT] Import parameter check for fclose from wine

### DIFF
--- a/sdk/lib/crt/stdio/file.c
+++ b/sdk/lib/crt/stdio/file.c
@@ -2784,6 +2784,8 @@ int CDECL fclose(FILE* file)
 {
   int r, flag;
 
+  if (!MSVCRT_CHECK_PMT(file != NULL)) return EOF;
+
   _lock_file(file);
   flag = file->_flag;
   free(file->_tmpfname);


### PR DESCRIPTION
Fixes advpack_apitest:DelNode crash.